### PR TITLE
Allow configuration of CssToInlineStyles class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('inliner_class')->defaultValue('TijsVerkoyen\CssToInlineStyles\CssToInlineStyles')->end()
+                ->booleanNode('cleanup')->defaultFalse()->end()
+                ->booleanNode('strip_original_style_tags')->defaultFalse()->end()
+                ->booleanNode('exclude_media_queries')->defaultTrue()->end()
             ->end()
         ;
 

--- a/DependencyInjection/TrtSwiftCssInlinerExtension.php
+++ b/DependencyInjection/TrtSwiftCssInlinerExtension.php
@@ -21,7 +21,11 @@ class TrtSwiftCssInlinerExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+
         $container->setParameter($this->getAlias().'.inliner_class', $config['inliner_class']);
+        $container->setParameter($this->getAlias().'.cleanup', $config['cleanup']);
+        $container->setParameter($this->getAlias().'.strip_original_style_tags', $config['strip_original_style_tags']);
+        $container->setParameter($this->getAlias().'.exclude_media_queries', $config['exclude_media_queries']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/README.md
+++ b/README.md
@@ -99,3 +99,18 @@ $message->getHeaders()->addTextHeader(
 ``` php
 $this->get('mailer')->send($message);
 ```
+
+#4. Configuration options
+
+No configuration is necessary.
+
+It is possible to customize the behaviour of the [CssToInlineStyles](https://github.com/tijsverkoyen/CssToInlineStyles) class. This shows the default options:
+
+``` yaml
+# app/config/config.yml
+trt_swift_css_inliner:
+    inliner_class: TijsVerkoyen\CssToInlineStyles\CssToInlineStyles
+    cleanup: false
+    strip_original_style_tags: false
+    exclude_media_queries: true
+```

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,7 +11,17 @@
     </parameters>
 
     <services>
-        <service id="trt_swift_css_inliner.css_converter" class="%trt_swift_css_inliner.inliner_class%" />
+        <service id="trt_swift_css_inliner.css_converter" class="%trt_swift_css_inliner.inliner_class%">
+            <call method="setCleanup">
+                <argument>%trt_swift_css_inliner.cleanup%</argument>
+            </call>
+            <call method="setStripOriginalStyleTags">
+                <argument>%trt_swift_css_inliner.strip_original_style_tags%</argument>
+            </call>
+            <call method="setExcludeMediaQueries">
+                <argument>%trt_swift_css_inliner.exclude_media_queries%</argument>
+            </call>
+        </service>
 
         <service id="trt_swift_css_inliner.header_decoder" class="%trt_swift_css_inliner.header_decoder.class%" />
 


### PR DESCRIPTION
It would be nice if it was easy to change the behaviour of the CssToInlineStyles class. This patch adds some configuration options for three options, setCleanup(), setStripOriginalStyleTags(), and setExcludeMediaQueries().

I left out setUseInlineStylesBlock() and setCSS(), because they are invoked directly by this bundle.