### PR TITLE
Upgrade CssToInlineStyles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.3.3",
         "symfony/symfony": ">=2.3.4",
         "symfony/swiftmailer-bundle": "~2.3",
-        "tijsverkoyen/css-to-inline-styles": "1.2.*"
+        "tijsverkoyen/css-to-inline-styles": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
The current version of CssToInlineStyles is 1.5.4, but SwiftCssInlinerBundle requires 1.2.*. Because of semantic versioning, it is safe to requires any version ≥ 1.2 and < 2.0.

Many exciting improvements has been made since 1.2.x:
https://github.com/tijsverkoyen/CssToInlineStyles/blob/master/CHANGELOG.md
